### PR TITLE
Add overview of 12-factor application to README.md

### DIFF
--- a/12-factor-application/pom.xml
+++ b/12-factor-application/pom.xml
@@ -16,7 +16,7 @@
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>https://raw.github.com/WASdev/sample.async.websockets/master/LICENSE</url>
+            <url>https://raw.github.com/WASdev/sample.microservices.12factorapp/master/LICENSE</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Twelve-Factor Applications with Liberty
 
-This sample contains an example for a Twelve-Factor Application that can be run on Liberty and Bluemix. A Twelve-Factor App is an application that follows the methodology described here: [12factor.net](http://www.12factor.net) and is also a great methodology to use when following a microservices architecture.
+A Twelve-Factor application, as defined by [12factor.net](http://www.12factor.net), has characteristics that are ideal for developing individual microservices. To summarize briefly, a twelve-factor application:
+
+1. is stored in a single codebase, tracked in a version control system: one codebase, many deployments. 
+2. has explicitly declared and isolated external dependencies
+3. has deployment-specific configuration stored in environment variables, and not in the code
+4. treats backing services (e.g. data stores, message queues, etc.) as attached/replaceable resources
+5. is built in distinct stages (build, release, run), with strict separation between them (no knock-on effects or cycles)
+6. runs as one or more stateless processes that share nothing, and assume process memory is transient
+7. is completely self-contained, and provides a service endpoint on well-defined (environment determined) host and port
+8. is managed and scaled via process instances (horizontal scaling)
+9. is disposable, with minimal startup, graceful shutdown, and toleration for abrupt process termination 
+10. is designed for continuous development/deployment, with minimal difference between the app in development and the app in production
+11. treats logs as event streams: the outer/hosting environment deals with processing and routing log files.
+12. keeps one-off admin scripts with the application, to ensure the admin scripts run with the same environment as the application itself.
+
+
+This sample contains an example for a Twelve-Factor Application that can be run on WAS Liberty and Bluemix. 
+
 
 * Building this sample:
 	* [Building with Gradle](/docs/Building-the-sample.md#building-with-gradle)

--- a/docs/Building-the-sample.md
+++ b/docs/Building-the-sample.md
@@ -3,12 +3,12 @@ This sample can be built using either [Gradle](#building-with-gradle) or [Maven]
 In addition to publishing the war to the local maven repository, the built war file is copied into the apps directory of the server configuration located in the 12-factor-wlpcfg directory:
 
 ```text
-async-websocket-wlpcfg
+12-factor-wlpcfg
  +- servers
      +- websocketSample                        <-- specific server configuration
         +- server.xml                          <-- server configuration
         +- apps                                <- directory for applications
-           +- async-websocket-application.war  <- sample application
+           +- 12-factor-application.war        <- sample application
         +- logs                                <- created by running the server locally
         +- workarea                            <- created by running the server locally
 ```
@@ -25,7 +25,7 @@ $ gradle build publishToMavenLocal
 [Download WAS Liberty manually](/docs/Downloading-WAS-Liberty.md) then in a command line navigate to the wlp/bin directory of your Liberty Runtime. Set the environment variable 'WLP_USER_DIR' to point to your 12-factor-wlpcfg project then run:
 
 ```bash
-$ server.bat package 12FactorAppServer --include=usr
+$ server package 12FactorAppServer --include=usr
 ```
 
 This will give you a 12FactorAppServer.zip which contains your packaged server.
@@ -33,7 +33,9 @@ This will give you a 12FactorAppServer.zip which contains your packaged server.
 
 ## Building with maven
 
-This sample can be built using [Apache Maven](http://maven.apache.org/). The build will pull down a copy of Liberty, build the sample and produce a packaged liberty server that can be run locally or pushed up to Bluemix. Before building the sample you must add the License Code to the pom.xml file in the 12-factor-wlpcfg project. You can obtain the license code by reading the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.5/lafiles/runtime/en.html) and looking for the 'D/N: <license code>' line.
+This sample can be built using [Apache Maven](http://maven.apache.org/). The build will pull down a copy of Liberty, build the sample and produce a packaged liberty server that can be run locally or pushed up to Bluemix. 
+
+:pushpin: Note: Before building the sample you must add the License Code to the pom.xml file in the 12-factor-wlpcfg project. You can obtain the license code by reading the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.5/lafiles/runtime/en.html) and looking for the 'D/N: <license code>' line.
 
 ```bash
 $ mvn install

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>https://raw.github.com/WASdev/sample.async.websockets/master/LICENSE</url>
+            <url>https://raw.github.com/WASdev/sample.microservices.12factorapp/master/LICENSE</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
Update README with an overview of what a 12-factor app is (more should be added about the sample itself). Revised the WDT doc a bit, added a pushpin emoji for the note about obtaining the license, and changed from server.bat to server, as using server alone will work on both windows and non-windows systems. Also fixed project references in pom files.
