### PR TITLE
Improve options for downloading Liberty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.settings
 /.plxarc
 /target
+*.swp
+wlp-install.properties

--- a/12-factor-application/pom.xml
+++ b/12-factor-application/pom.xml
@@ -26,21 +26,24 @@
         <developerConnection>scm:git@github.com:WASdev/sample.microservices.12factorapp.git</developerConnection>
         <url>git@github.com:WASdev/sample.microservices.12factorapp.git</url>
     </scm>
-    
-    <properties>
-        <!-- Default location of local liberty or target install directory if libertyLicense system property specified -->
-        <!-- To specify a new location set a system property called libertyInstallBaseDir to point to this location e.g. mvn -DlibertyInstallBaseDir=<location> install -->
-        <libertyBaseDir>C:/Liberty</libertyBaseDir>
-        <!-- Update this to match the port number in the 12-factor-wlpcfg/servers/12FactorAppServer/server.xml
-        This is needed to run the tests -->
-        <libertyTestPort>9082</libertyTestPort>
-        <skipFVT>true</skipFVT>
-        <skipPackage>true</skipPackage>
-    </properties>
 
+    <properties>
+	<installFile>${basedir}/../wlp-install.properties</installFile>
+        <testFile>${basedir}/../devtest.properties</testFile>
+        <serverName>12FactorAppServer</serverName>
+        <userDir>${basedir}/../12-factor-wlpcfg</userDir>
+        <serverDir>${userDir}/servers/${serverName}</serverDir>
+
+        <skipPackage>true</skipPackage>
+
+        <!-- allow tests to be skipped if a wlp dir can't be found without failing the build,
+             use the requireAllTests profile to override -->
+        <skipEnforceTests>true</skipEnforceTests>
+    </properties>
+    
     <dependencyManagement>
         <dependencies>
-        <dependency>
+            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>
@@ -104,23 +107,14 @@
             <artifactId>javax.json</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.wasdev.wlp.sample</groupId>
+            <artifactId>12-factor-wlpcfg</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
     </dependencies>
     
-    <pluginRepositories>
-        <!-- Configure Sonatype OSS Maven snapshots repository-->
-        <pluginRepository>
-        <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <plugins>
             <plugin>
@@ -131,6 +125,27 @@
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
+            <!-- Read file(s) containing development and test properties -->
+            <plugin>
+        	<groupId>org.codehaus.mojo</groupId>
+        	<artifactId>properties-maven-plugin</artifactId>
+        	<version>1.0-alpha-2</version>
+        	<executions>
+          	    <execution>
+            		<phase>initialize</phase>
+            		<goals>
+              		    <goal>read-project-properties</goal>
+            		</goals>
+            		<configuration>
+             		    <files>
+                		<file>${installFile}</file>
+                		<file>${testFile}</file>
+             	 	    </files>
+           		</configuration>
+          	    </execution>
+        	</executions>
+	    </plugin>
+            <!-- Copy war to wlpcfg for both later packaging and test -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -142,7 +157,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${basedir}/../12-factor-wlpcfg/servers/12FactorAppServer/apps</outputDirectory>
+                            <outputDirectory>${serverDir}/apps</outputDirectory>
                             <silent>true</silent>
                             <stripVersion>true</stripVersion>
                             <artifactItems>
@@ -157,11 +172,17 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Enable liberty-maven-plugin -->
+            <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>1.1-SNAPSHOT</version>
+                <configuration>
+                    <serverName>${serverName}</serverName>
+                    <installDirectory>${wlp.install.dir}</installDirectory>
+                    <userDirectory>${userDir}</userDirectory>
+                    <outputDirectory>${project.build.directory}/wlp.output</outputDirectory>
+                </configuration>
                 <executions>
                     <execution>
                         <id>package-server</id>
@@ -170,9 +191,9 @@
                             <goal>package-server</goal>
                         </goals>
                         <configuration>
-                            <packageFile>${basedir}/../12-factor-wlpcfg</packageFile>
+                            <skip>${wlp.bad.install}</skip>
+                            <packageFile>${project.build.directory}/${serverName}.zip</packageFile>
                             <include>usr</include>
-                            <skip>${skipPackage}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -182,8 +203,7 @@
                             <goal>start-server</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipFVT}</skip>
-                            <configFiles>${basedir}/../async-websocket-wlpcfg/servers/websocketSample/server.xml</configFiles>
+                            <skip>${wlp.bad.install}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -193,14 +213,10 @@
                             <goal>stop-server</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipFVT}</skip>
+                            <skip>${wlp.bad.install}</skip>
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <userDirectory>../12-factor-wlpcfg</userDirectory>
-                    <serverName>12FactorAppServer</serverName>
-                </configuration>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
@@ -222,7 +238,7 @@
                                 <exclude>**/unit/**</exclude>
                             </excludes>
                             <systemPropertyVariables>
-                                <liberty.test.port>${libertyTestPort}</liberty.test.port>
+                                <liberty.test.port>${libertyPort}</liberty.test.port>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -234,7 +250,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <skip>${skipFVT}</skip>
+                    <skip>${wlp.bad.install}</skip>
                     <summaryFile>${project.build.directory}/test-reports/fvt/failsafe-summary.xml</summaryFile>
                     <reportsDirectory>${project.build.directory}/test-reports/fvt</reportsDirectory>
                 </configuration>
@@ -260,109 +276,41 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipEnforceTests}</skip>
+                            <rules>
+                                <requireProperty>
+                                    <property>wlp.bad.install</property>
+                                    <message>Must run all tests. Tests may be skipped because of bad WAS Liberty install at ${wlp.install.dir}</message>
+                                    <regex>false</regex>
+                                    <regexMessage>wlp.bad.install=${wlp.bad.install} -- it should be false</regexMessage>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
-            <id>install-liberty-from-plugin</id>
-            <activation>
-                 <property>
-                    <name>libertyLicense</name>
-                 </property>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- Enable liberty-maven-plugin -->
-                    <plugin>
-                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
-                        <artifactId>liberty-maven-plugin</artifactId>
-                        <version>1.1-SNAPSHOT</version>
-                        <configuration>
-                            <install>
-                                <licenseCode>${libertyLicense}</licenseCode>
-                                <version>8.5.5_06</version>
-                            </install>
-                            <assemblyInstallDirectory>${libertyBaseDir}</assemblyInstallDirectory>
-                        </configuration>
-                    </plugin>
-                 </plugins>
-             </build>
-             <properties>
-                <skipFVT>true</skipFVT>
-                <skipPackage>false</skipPackage>
-             </properties>
-        </profile>
-        <profile>
-            <!-- To install liberty set the current Liberty license code as the system
-                 property libertyLicense. See github docs for more details. -->
-            <id>not-installing-liberty</id>
-            <activation>
-                <property>
-                    <name>!libertyLicense</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- Enable liberty-maven-plugin -->
-                    <plugin>
-                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
-                        <artifactId>liberty-maven-plugin</artifactId>
-                        <version>1.1-SNAPSHOT</version>
-                        <configuration>
-                            <installDirectory>${libertyBaseDir}/wlp</installDirectory>
-                        </configuration>
-                    </plugin>
-                 </plugins>
-             </build>
-        </profile>
-        <profile>
-            <id>check-default-liberty-present</id>
-            <activation>
-                <file>
-                    <exists>C:/Liberty/wlp/lib/ws-launch.jar</exists>
-                </file>
-            </activation>
+            <id>requireAllTests</id>
             <properties>
-                <skipPackage>false</skipPackage>
-                <libertyBaseDir>C:/Liberty</libertyBaseDir>
+                <skipEnforceTests>false</skipEnforceTests>
             </properties>
         </profile>
-        <profile>
-            <id>check-for-default-java-ee7</id>
-            <activation>
-                <file>
-                    <exists>C:/Liberty/wlp/lib/features/javaee-7.0.mf</exists>
-                </file>
-            </activation>
-            <properties>
-                <skipFVT>false</skipFVT>
-                <libertyBaseDir>C:/Liberty</libertyBaseDir>
-            </properties>
-        </profile>
-        <profile>
-            <id>check-liberty-present</id>
-            <activation>
-                <file>
-                    <exists>${libertyInstallBaseDir}/wlp/lib/ws-launch.jar</exists>
-                </file>
-            </activation>
-            <properties>
-                <skipPackage>false</skipPackage>
-                <libertyBaseDir>${libertyInstallBaseDir}</libertyBaseDir>
-            </properties>
-        </profile>
-        <profile>
-            <id>check-for-java-ee7</id>
-            <activation>
-                <file>
-                    <exists>${libertyInstallBaseDir}/wlp/lib/features/javaee-7.0.mf</exists>
-                </file>
-            </activation>
-            <properties>
-                <skipFVT>false</skipFVT>
-                <libertyBaseDir>${libertyInstallBaseDir}</libertyBaseDir>
-            </properties>
-        </profile>
-    </profiles>
+    </profiles> 
+
 </project>

--- a/12-factor-application/pom.xml
+++ b/12-factor-application/pom.xml
@@ -28,11 +28,13 @@
     </scm>
 
     <properties>
-	<installFile>${basedir}/../wlp-install.properties</installFile>
-        <testFile>${basedir}/../devtest.properties</testFile>
-        <serverName>12FactorAppServer</serverName>
-        <userDir>${basedir}/../12-factor-wlpcfg</userDir>
-        <serverDir>${userDir}/servers/${serverName}</serverDir>
+        <wlpInstallProps>${project.parent.basedir}/wlp-install.properties</wlpInstallProps>
+        <devtestProps>${project.parent.basedir}/devtest.properties</devtestProps>
+ 
+        <wlpServerName>12FactorAppServer</wlpServerName>
+        <wlpUserDir>${project.parent.basedir}/12-factor-wlpcfg</wlpUserDir>
+        <wlpServerDir>${wlpUserDir}/servers/${wlpServerName}</wlpServerDir>
+        <wlpOutputDir>${project.build.directory}/wlp.output</wlpOutputDir>
 
         <skipPackage>true</skipPackage>
 
@@ -137,10 +139,10 @@
               		    <goal>read-project-properties</goal>
             		</goals>
             		<configuration>
-             		    <files>
-                		<file>${installFile}</file>
-                		<file>${testFile}</file>
-             	 	    </files>
+                            <files>
+                                <file>${wlpInstallProps}</file>
+                                <file>${devtestProps}</file>
+                            </files>
            		</configuration>
           	    </execution>
         	</executions>
@@ -157,7 +159,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${serverDir}/apps</outputDirectory>
+                            <outputDirectory>${wlpServerDir}/apps</outputDirectory>
                             <silent>true</silent>
                             <stripVersion>true</stripVersion>
                             <artifactItems>
@@ -176,12 +178,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>1.1-SNAPSHOT</version>
                 <configuration>
-                    <serverName>${serverName}</serverName>
+                    <serverName>${wlpServerName}</serverName>
                     <installDirectory>${wlp.install.dir}</installDirectory>
-                    <userDirectory>${userDir}</userDirectory>
-                    <outputDirectory>${project.build.directory}/wlp.output</outputDirectory>
+                    <userDirectory>${wlpUserDir}</userDirectory>
+                    <outputDirectory>${wlpOutputDir}</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>
@@ -192,7 +193,7 @@
                         </goals>
                         <configuration>
                             <skip>${wlp.bad.install}</skip>
-                            <packageFile>${project.build.directory}/${serverName}.zip</packageFile>
+                            <packageFile>${project.build.directory}/${wlpServerName}.zip</packageFile>
                             <include>usr</include>
                         </configuration>
                     </execution>
@@ -279,7 +280,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>

--- a/12-factor-wlpcfg/pom.xml
+++ b/12-factor-wlpcfg/pom.xml
@@ -14,9 +14,20 @@
     <packaging>pom</packaging>
     <name>WAS Liberty Sample - Twelve Factor Sample Server Configuration</name>
     <url>https://wasdev.github.io</url>
-    
+
+
     <properties>
-	<installFile>${basedir}/../wlp-install.properties</installFile>
+        <wlpInstallProps>${basedir}/../wlp-install.properties</wlpInstallProps>
+        <devtestProps>${basedir}/../devtest.properties</devtestProps>
+
+        <wlpUserDir>${basedir}</wlpUserDir>
+        <wlpServerName>12FactorAppServer</wlpServerName>
+        <wlpServerDir>${wlpUserDir}/servers/${wlpServerName}</wlpServerDir>
+
+        <selectNewInstall>false</selectNewInstall>
+        <existingInstall>true</existingInstall>
+
+        <wlp.acceptLicense>false</wlp.acceptLicense>
     </properties>
 
     <!-- This pom is built first (before application) as the application will use what is downloaded here to test/build against.
@@ -35,11 +46,12 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${selectNewInstall}</skip>
                             <exportAntProperties>true</exportAntProperties>
-                            <target unless="selectNewInstall">
+                            <target>
                                 <!-- only run when a profile is not specified -->
                                 <!-- Read the properties file that should already exist (no failure if not) -->
-                                <property file="${installFile}" />
+                                <property file="${wlpInstallProps}" />
                                 
                                 <!-- sane default should we have nothing -->
                                 <property name="wlp.install.dir" value="${project.build.directory}/liberty"/>
@@ -52,7 +64,7 @@
 
                     <execution>
                         <id>find-wlp</id>
-                        <phase>process-resources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
@@ -73,7 +85,7 @@
                                 </condition>
 
                                 <!-- Create (or recreate) the version file -->
-                                <echo file="${installFile}"># Generated file, rebuilt with every build
+                                <echo file="${wlpInstallProps}"># Generated file, rebuilt with every build
 wlp.bad.install=${dirs.missing}
 wlp.install.dir=${wlp.install.dir}
 </echo>
@@ -84,7 +96,7 @@ wlp.install.dir=${wlp.install.dir}
 
                     <execution>
                         <id>messages</id>
-                        <phase>verify</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
@@ -97,29 +109,61 @@ This can be corrected in a few ways:
 
 * mvn install -Pmvn-download 
     This will download a development version of WAS Liberty.
-    Optionally: -Dwlp.version=version, e.g. 8.5.+
-                -Dwlp.install.dir=/path/to/wlp
+    Optionally: wlp.version=version, e.g. 8.5.+
+                wlp.install.dir=/path/to/parent (liberty will be installed into that dir)
 
 * mvn install -Pwlp-download -Dwlp.license=license_string
     This will download a licensed version of WAS Liberty.
-    Optionally: -Dwlp.version=version, 8.5.+
-                -Dwlp.install.dir=/path/to/wlp
+    Optionally: wlp.version=version, 8.5.+
+                wlp.target.dir=/path/to/parent  (liberty will be installed into that dir)
 
 * mvn install -Pwlp-install -Dwlp.install.dir=/path/to/wlp
     This will use the specified local installation of WAS Liberty.
 
-
 wlp.install.dir is either unset, not a directory, or not a valid Liberty installation.
 The current value is ${wlp.install.dir}
-${read.wlp-install.properties}
+
+Specify wlp.acceptLicense=true to automatically accept licenses associated with 
+runtime and feature downloads in automated builds.
+
 </echo>
 <fail unless="read.wlp-install.properties" message="Incorrect selection of WAS Liberty installation." />
                             </target>
                         </configuration>
                     </execution>
-
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <configuration>
+                    <serverName>${wlpServerName}</serverName>
+                    <userDirectory>${wlpUserDir}</userDirectory>
+                    <outputDirectory>${project.build.directory}/wlp.output</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${existingInstall}</skip>
+	                    <installDirectory>${wlp.install.dir}</installDirectory>
+                            <features>
+                                <acceptLicense>${wlp.acceptLicense}</acceptLicense>
+                                <feature>jaxrs-2.0</feature>
+                                <feature>jsonp-1.0</feature>
+                                <feature>monitor-1.0</feature>
+                                <feature>restConnector-1.0</feature>
+                            </features>
+                        </configuration>
+                    </execution> 
+                </executions>
+            </plugin>
+
 
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -158,9 +202,11 @@ ${read.wlp-install.properties}
                 <!-- Default location to download liberty -->
                 <wlp.install.dir>${project.build.directory}/liberty</wlp.install.dir>
                 <!-- Default version -->
-                 <wlp.version>8.5.+</wlp.version>
-		<!-- After choosing this profile, regenerate the versions file -->
-                 <selectNewInstall>false</selectNewInstall>
+                <wlp.version>8.5.+</wlp.version>
+
+		<!-- Yes, we are selecting a new profile (don't read the old file) -->
+                <selectNewInstall>true</selectNewInstall>
+                <existingInstall>false</existingInstall>
             </properties>
             <build>
                 <plugins>
@@ -197,32 +243,71 @@ ${read.wlp-install.properties}
              Activate this profile (-Pwlp-download) and provide the following properties: 
                 -Dwlp.license=<value>
              	-Dwlp.version=<value> (optional)
-                -Dwlp.install.dir=<value> (optional) 
+                -Dwlp.target.dir=<value> (optional, the wlp dir will be inside this dir) 
              Versions are specified here: http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml -->
         <profile>
             <id>wlp-download</id>
             <properties>
                 <!-- Default location to download liberty -->
-                <wlp.install.dir>${project.build.directory}/liberty</wlp.install.dir>
+                <wlp.target.dir>${project.build.directory}/liberty</wlp.target.dir>
+                <wlp.install.dir>${project.build.directory}/liberty/wlp</wlp.install.dir>
                 <!-- Default version -->
                 <wlp.version>8.5.+</wlp.version>
-		<!-- After choosing this profile, regenerate the versions file -->
+
+		<!-- Yes, we are selecting a new profile (don't read the old file) -->
                 <selectNewInstall>true</selectNewInstall>
+                <existingInstall>false</existingInstall>
             </properties>
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-license</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <property>wlp.license</property>
+                                            <message>The wlp.license property must be provided with this profile, e.g. -Dwlp.license=&lt;license_string&gt;</message>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
                         <groupId>net.wasdev.wlp.maven.plugins</groupId>
                         <artifactId>liberty-maven-plugin</artifactId>
-                        <version>1.1-SNAPSHOT</version>                        
                         <configuration>
-                            <install>
-                            	<licenseCode>${wlp.license}</licenseCode>
-                                <version>${wlp.version}</version>
-				<assemblyInstallDirectory>${wlp.install.dir}</assemblyInstallDirectory>
-                            </install>
+                            <serverName>${wlpServerName}</serverName>
+                            <userDirectory>${wlpUserDir}</userDirectory>
+                            <outputDirectory>${project.build.directory}/wlp.output</outputDirectory>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>downloading-wlp</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>server-status</goal>
+                                </goals>
+                                <configuration>
+		                    <assemblyInstallDirectory>${wlp.target.dir}</assemblyInstallDirectory>
+                                    <install>
+                                        <licenseCode>${wlp.license}</licenseCode>
+                                        <version>${wlp.version}</version>
+                                    </install>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
+
                 </plugins>
             </build>
 	</profile>
@@ -234,8 +319,9 @@ ${read.wlp-install.properties}
         <profile>
             <id>wlp-install</id>
             <properties>
-		<!-- After choosing this profile, regenerate the versions file -->
+		<!-- Yes, we are selecting a new profile (don't read the old file) -->
                 <selectNewInstall>true</selectNewInstall>
+                <existingInstall>false</existingInstall>
             </properties>
 	</profile>
 

--- a/12-factor-wlpcfg/pom.xml
+++ b/12-factor-wlpcfg/pom.xml
@@ -191,54 +191,6 @@ runtime and feature downloads in automated builds.
     
     <profiles>
 
-        <!-- Profile to download liberty from maven repository. 
-             Activate this profile (-Pmvn-download) and provide 
-             the following properties: 
-             	-Dwlp.version=<value>  (optional)
-                -Dwlp.install.dir=<value> (optional) -->
-        <profile>
-            <id>mvn-download</id>
-            <properties>
-                <!-- Default location to download liberty -->
-                <wlp.install.dir>${project.build.directory}/liberty</wlp.install.dir>
-                <!-- Default version -->
-                <wlp.version>8.5.+</wlp.version>
-
-		<!-- Yes, we are selecting a new profile (don't read the old file) -->
-                <selectNewInstall>true</selectNewInstall>
-                <existingInstall>false</existingInstall>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>mvn-download</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>com.ibm.websphere.appserver.runtime</groupId>
-                                            <artifactId>wlp-webProfile7</artifactId>
-                                            <version>${wlp.version}</version>
-                                            <type>zip</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${wlp.install.dir}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-			</executions>
-                    </plugin>
-                </plugins>
-            </build>
-	</profile>
-
         <!-- Profile to download licensed liberty from the Liberty repository. 
              Activate this profile (-Pwlp-download) and provide the following properties: 
                 -Dwlp.license=<value>

--- a/12-factor-wlpcfg/pom.xml
+++ b/12-factor-wlpcfg/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
@@ -16,8 +15,112 @@
     <name>WAS Liberty Sample - Twelve Factor Sample Server Configuration</name>
     <url>https://wasdev.github.io</url>
     
+    <properties>
+	<installFile>${basedir}/../wlp-install.properties</installFile>
+    </properties>
+
+    <!-- This pom is built first (before application) as the application will use what is downloaded here to test/build against.
+         Enable one of the profiles below to download Liberty (or select an existing one) -->
     <build>
     	<plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+
+                    <execution>
+                        <id>read-properties</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <exportAntProperties>true</exportAntProperties>
+                            <target unless="selectNewInstall">
+                                <!-- only run when a profile is not specified -->
+                                <!-- Read the properties file that should already exist (no failure if not) -->
+                                <property file="${installFile}" />
+                                
+                                <!-- sane default should we have nothing -->
+                                <property name="wlp.install.dir" value="${project.build.directory}/liberty"/>
+
+                                <!-- set a property to indicate that we read properties -->
+                                <property name="read.wlp-install.properties" value="true" />
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>find-wlp</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <exportAntProperties>true</exportAntProperties>
+                            <target>
+                                <!-- Check the wlp.install.dir, and ensure it contains a liberty install -->
+                                <condition property="valid.wlp">
+                                    <and>
+                                        <available file="${wlp.install.dir}" type="dir" />
+                                        <available file="${wlp.install.dir}/lib/ws-launch.jar" type="file" />
+                                    </and>
+                                </condition>
+                                
+                                <!-- Some tests need to be disabled if we don't have a valid liberty around -->
+                                <condition property="dirs.missing" value="false" else="true">
+                                    <isset property="valid.wlp" />
+                                </condition>
+
+                                <!-- Create (or recreate) the version file -->
+                                <echo file="${installFile}"># Generated file, rebuilt with every build
+wlp.bad.install=${dirs.missing}
+wlp.install.dir=${wlp.install.dir}
+</echo>
+
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>messages</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target unless="valid.wlp">
+<echo> ---
+NOTE: Integration tests will be disabled until a valid wlp installation is located.
+
+This can be corrected in a few ways: 
+
+* mvn install -Pmvn-download 
+    This will download a development version of WAS Liberty.
+    Optionally: -Dwlp.version=version, e.g. 8.5.+
+                -Dwlp.install.dir=/path/to/wlp
+
+* mvn install -Pwlp-download -Dwlp.license=license_string
+    This will download a licensed version of WAS Liberty.
+    Optionally: -Dwlp.version=version, 8.5.+
+                -Dwlp.install.dir=/path/to/wlp
+
+* mvn install -Pwlp-install -Dwlp.install.dir=/path/to/wlp
+    This will use the specified local installation of WAS Liberty.
+
+
+wlp.install.dir is either unset, not a directory, or not a valid Liberty installation.
+The current value is ${wlp.install.dir}
+${read.wlp-install.properties}
+</echo>
+<fail unless="read.wlp-install.properties" message="Incorrect selection of WAS Liberty installation." />
+                            </target>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>2.6.1</version>
@@ -42,4 +145,99 @@
     	</plugins>
     </build>
     
+    <profiles>
+
+        <!-- Profile to download liberty from maven repository. 
+             Activate this profile (-Pmvn-download) and provide 
+             the following properties: 
+             	-Dwlp.version=<value>  (optional)
+                -Dwlp.install.dir=<value> (optional) -->
+        <profile>
+            <id>mvn-download</id>
+            <properties>
+                <!-- Default location to download liberty -->
+                <wlp.install.dir>${project.build.directory}/liberty</wlp.install.dir>
+                <!-- Default version -->
+                 <wlp.version>8.5.+</wlp.version>
+		<!-- After choosing this profile, regenerate the versions file -->
+                 <selectNewInstall>false</selectNewInstall>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>mvn-download</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                                            <artifactId>wlp-webProfile7</artifactId>
+                                            <version>${wlp.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${wlp.install.dir}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+			</executions>
+                    </plugin>
+                </plugins>
+            </build>
+	</profile>
+
+        <!-- Profile to download licensed liberty from the Liberty repository. 
+             Activate this profile (-Pwlp-download) and provide the following properties: 
+                -Dwlp.license=<value>
+             	-Dwlp.version=<value> (optional)
+                -Dwlp.install.dir=<value> (optional) 
+             Versions are specified here: http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml -->
+        <profile>
+            <id>wlp-download</id>
+            <properties>
+                <!-- Default location to download liberty -->
+                <wlp.install.dir>${project.build.directory}/liberty</wlp.install.dir>
+                <!-- Default version -->
+                <wlp.version>8.5.+</wlp.version>
+		<!-- After choosing this profile, regenerate the versions file -->
+                <selectNewInstall>true</selectNewInstall>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <version>1.1-SNAPSHOT</version>                        
+                        <configuration>
+                            <install>
+                            	<licenseCode>${wlp.license}</licenseCode>
+                                <version>${wlp.version}</version>
+				<assemblyInstallDirectory>${wlp.install.dir}</assemblyInstallDirectory>
+                            </install>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+	</profile>
+
+        <!-- Profile to use an existing liberty installation. 
+             Activate this profile (-Pwlp-install) and provide the following property: 
+                -Dwlp.install.dir=<value> 
+             Versions are specified here: http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml -->
+        <profile>
+            <id>wlp-install</id>
+            <properties>
+		<!-- After choosing this profile, regenerate the versions file -->
+                <selectNewInstall>true</selectNewInstall>
+            </properties>
+	</profile>
+
+    </profiles>
 </project>

--- a/devtest.properties
+++ b/devtest.properties
@@ -1,0 +1,6 @@
+# Port number
+# --------------
+# This port number should match the one in 12-factor-wlpcfg/servers/12FactorAppServer/server.xml for the functional tests to run successfully
+libertyPort=9082
+
+

--- a/docs/Building-the-sample.md
+++ b/docs/Building-the-sample.md
@@ -26,18 +26,32 @@ $ gradle build publishToMavenLocal
 
 ## Building with maven
 
-This sample can be built using [Apache Maven](http://maven.apache.org/). The build will pull down a copy of Liberty, build the sample and produce a packaged liberty server that can be run locally or pushed up to Bluemix. 
+This sample can be built using [Apache Maven](http://maven.apache.org/).
+
+By default, maven will build the sample and run unit tests.
 
 ```bash
 $ mvn install
 ```
 
-:pushpin: Note: To run functional tests and get a packaged server from the build you must [download WAS Liberty](/docs/Downloading-WAS-Liberty.md) to C:/Liberty/wlp.
-:pushpin: Note: To get a packaged server without manually downloading Liberty set the system property libertyLicense to be the Liberty license code. The license code can be found at the bottom of the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.5/lafiles/runtime/en.html), look for the 'D/N: <license code>'. This option does not currently support running the functional tests.
+Running integration tests and producing a fully packaged liberty server that can be run locally or pushed to Bluemix requires a valid installation of liberty to work with.
+
+* [Download WAS Liberty](/docs/Downloading-WAS-Liberty.md) yourself, and specify where the installation is:
 
 ```bash
-$ mvn -DlibertyLicense=<license> install
+$ mvn install -Pwlp-install -Dwlp.install.dir=/path/to/installed/wlp
 ```
+
+* Specify a licensed version of liberty that should be downloaded by the liberty-maven-plugin.
+
+    The current developer license (as you would get from a direct wasdev.net download) can be found at the bottom of the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.5/lafiles/runtime/en.html), look for the 'D/N: &lt;license code&gt;'.
+```bash
+$ mvn install -Pwlp-download -Dwlp.license=<license code>
+```
+
+Once a valid install has been located (e.g. when running locally), the install profile information can be omitted on the command line.
+
+Liberty will be downloaded into the target directory by default, which means the profile parameters will be required for the first install after a clean.
 
 ## Next step:
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,23 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                    <artifactId>liberty-maven-plugin</artifactId>
+                    <version>1.1-SNAPSHOT</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
     
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,33 @@
         <developerConnection>scm:git@github.com:WASdev/sample.microservices.12factorapp.git</developerConnection>
         <url>git@github.com:WASdev/sample.microservices.12factorapp.git</url>
     </scm>
+
+    <pluginRepositories>
+        <!-- Configure Sonatype OSS Maven snapshots repository (newer maven liberty plugin) -->
+        <pluginRepository>
+        <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
     
+    <repositories>
+        <repository>
+            <id>was-repo</id>
+            <name>WAS Liberty Maven Repository</name>
+            <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/</url>
+        </repository>
+    </repositories>
+
     <modules>
-    	<module>12-factor-application</module>
     	<module>12-factor-wlpcfg</module>
+    	<module>12-factor-application</module>
     </modules>
     
 </project>


### PR DESCRIPTION
Change the order of processing so wlpcfg is "built" first, and it takes care of finding/downloading/stashing away a runtime
--> some work still to do here, as I can't get the mvn-download profile to work
--> I think the ultimate output of wlpcfg should be a server archive assembly that the application project can then get as a dependency. The application project should stop copying the war into the wlpcfg project, and should instead unpack the generated package, add the war, and generate a final package that it can then use for running integration tests, etc.

wlpcfg generates/updates a properties file that indicates what the wlp.install.dir is, and whether or not it is valid.

default is to continue if the wlp install can't be found, and to use a profile when the build should fail if all tests can't be run. We can change the default if/when all of the download options work OOTB.
